### PR TITLE
Successfully added data from Form to the Cluster collection

### DIFF
--- a/client/src/actions/posts.js
+++ b/client/src/actions/posts.js
@@ -10,3 +10,13 @@ export const getPosts = () => async (dispatch) => {
     console.log(error.message);
   }
 }
+
+export const createPost = (post) => async (dispatch) => {
+  try {
+    const { data } = await api.createPost(post);
+
+    dispatch({ type: 'CREATE', payload: data });
+  } catch (error) {
+    console.log(error.message);
+  }
+}

--- a/client/src/api/index.js
+++ b/client/src/api/index.js
@@ -3,3 +3,4 @@ import axios from "axios";
 const url = "http://localhost:5000/posts";
 
 export const fetchPosts = () => axios.get(url);
+export const createPost = (newPost) => axios.post(url, newPost);

--- a/client/src/components/Form/Form.js
+++ b/client/src/components/Form/Form.js
@@ -1,5 +1,9 @@
 import React, { useState } from "react";
 import FileBase from "react-file-base64";
+// redux
+import { useDispatch } from "react-redux";
+// actions
+import { createPost } from "../../actions/posts";
 // material ui
 import { TextField, Button, Typography, Paper } from "@material-ui/core";
 // styles
@@ -14,9 +18,12 @@ const Form = () => {
     tags: '',
     selectedFile: ''
   });
+  const dispatch = useDispatch();
 
-  const handleSubmit = () => {
+  const handleSubmit = (e) => {
+    e.preventDefault();
 
+    dispatch(createPost(postData));
   }
 
   const clearForm = () => {

--- a/client/src/reducers/posts.js
+++ b/client/src/reducers/posts.js
@@ -3,7 +3,7 @@ export default (posts = [], action) => {
     case 'FETCH_ALL':
       return action.payload;
     case 'CREATE':
-      return posts;
+      return [...posts, action.payload];
     default:
       return posts;
   }


### PR DESCRIPTION
- added the _API request_ and the _action_ for the POST request
- exported `const createPost` from our `index.js` API
- in _actions_ we exported `createPost()` as we did with `getPosts()` action function
- after that we're going to import in `Form.js` that earlier created `useDispatch()` hook from `react-redux`
- in our _reducer_ `posts.js` have to send over an array of **posts** with spread all _Posts_ `{ ...posts }` and then have to add a new post => `{...posts, action.payload}`
- when the **User** try to submit form we successfully get data back in an array and also stored that data at our **Cluster** in **MongoDB** atlas collections